### PR TITLE
Corrected padding direction when reconstructing UUIDs with leading zeroes

### DIFF
--- a/src/Shortener.php
+++ b/src/Shortener.php
@@ -77,7 +77,7 @@ class Shortener
      */
     private function formatHex(string $hex): string
     {
-        $hex = str_pad($hex, 32, '0');
+        $hex = str_pad($hex, 32, '0', \STR_PAD_LEFT);
         preg_match('/([a-f0-9]{8})([a-f0-9]{4})([a-f0-9]{4})([a-f0-9]{4})([a-f0-9]{12})/', $hex, $matches);
         array_shift($matches);
         $expandedUUID = implode('-', $matches);

--- a/tests/ShortenerTest.php
+++ b/tests/ShortenerTest.php
@@ -33,7 +33,25 @@ class ShortenerTest extends TestCase
             ['4e52c919-513e-4562-9248-7dd612c6c1ca', 'fpfyRTmt6XeE9ehEKZ5LwF'],
             ['806d0969-95b3-433b-976f-774611fdacbb', 'mavTAjNm4NVztDwh4gdSrQ'],
             ['0c5873e8-7fea-4570-9487-ffe96ec30257', 'LpGtrrQFCbneY2GtQiXDD4'],
+            'One leading zero'                  => ['07fe2146-0a94-4a4a-9956-4cfd0d3560d9', 'rcPMmyWuaewoF8EM3JK5S3'],
+            '2 Leading zeroes'                  => ['00fe2146-0a94-4a4a-9956-4cfd0d3560d9', 'qgXznd8uPVbCJg5tB5r5C'],
+            'Smallest UUID, max leading zeroes' => ['00000000-0000-0000-0000-000000000001', '3'],
+            'Small UUID, many leading zeroes'   => ['00000000-0000-0000-0000-0000000000aa', 'z4'],
+            'Large UUID, many trailing zeroes'  => ['aa000000-0000-0000-0000-000000000000', 'ABitJoXBZDBeRvbiWuB5GY'],
+            'Random UUID with trailing zeroes'  => ['a7fe2146-0a94-4a4a-9956-4cfd0d3560d0', 'Fbab7rU5aCkhaybY3jphtX'],
         ];
+    }
+
+    /**
+     * @test
+     * @dataProvider uuidShortenedUnmistakable
+     */
+    public function uuids_and_short_uuids_are_isomorphisms(string $uuid)
+    {
+        self::assertSame(
+            $uuid,
+            $this->shortener->expand($this->shortener->reduce($uuid))
+        );
     }
 
     /**


### PR DESCRIPTION
This is a typical case of "PHP's API is terrible and needs to burn in hell": easy
to mess up when a parameter completely changes the behavior of a function.