### PR TITLE
Improved `GMPShortener` performance even further by using `ext-gmp`'s built-in base conversion feature

### DIFF
--- a/src/GMPShortener.php
+++ b/src/GMPShortener.php
@@ -5,17 +5,16 @@ declare(strict_types=1);
 namespace Keiko\Uuid\Shortener;
 
 use Keiko\Uuid\Shortener\Exception\DictionaryException;
-use function gmp_add;
-use function gmp_cmp;
-use function gmp_div_q;
+use function array_flip;
 use function gmp_init;
-use function gmp_intval;
-use function gmp_mod;
 use function gmp_strval;
+use function preg_match;
+use function preg_quote;
 use function str_pad;
 use function str_replace;
+use function strrev;
+use function strtr;
 use function substr;
-use const GMP_ROUND_ZERO;
 use const STR_PAD_LEFT;
 
 /** @psalm-immutable */
@@ -24,41 +23,57 @@ final class GMPShortener extends Shortener
     /** @var Dictionary */
     private $dictionary;
 
+    /**
+     * @var string[] a map of character replacements to be used when translating a number that is
+     *               in base(length(Dictionary)) (keys) to the dictionary characters (values).
+     *
+     * @psalm-var non-empty-array<non-empty-string, non-empty-string>
+     */
+    private $baseReplacements;
+
+    /** @var string */
+    private $allowedCharactersMatcher;
+
     public function __construct(Dictionary $dictionary)
     {
         $this->dictionary = $dictionary;
+
+        $replacements = [];
+
+        foreach (range(0, $dictionary->length - 1) as $characterIndex) {
+            $replacements[gmp_strval(gmp_init((string) $characterIndex, 10), $dictionary->length)] = $dictionary->charsSet[$characterIndex];
+        }
+
+        $this->baseReplacements = $replacements;
+        $this->allowedCharactersMatcher = '/^['. preg_quote($dictionary->charsSet, '/').']+$/';
     }
 
     public function reduce(string $uuid): string
     {
-        $dictionaryLength = gmp_init($this->dictionary->length, 10);
-        $uuidInt = gmp_strval(gmp_init(str_replace('-', '', $uuid), 16));
-        $output = '';
-
-        while (gmp_cmp($uuidInt, '0') > 0) {
-            $output .= $this->dictionary->charsSet[gmp_intval(gmp_mod($uuidInt, $dictionaryLength))];
-
-            $uuidInt = gmp_div_q($uuidInt, $dictionaryLength, GMP_ROUND_ZERO);
-        }
-
-        return $output;
+        return strrev(strtr(
+            gmp_strval(gmp_init(str_replace('-', '', $uuid), 16), $this->dictionary->length),
+            $this->baseReplacements
+        ));
     }
 
     public function expand(string $shortUuid): string
     {
-        $number = gmp_init(0, 10);
-        $dictionaryLength = gmp_init($this->dictionary->length, 10);
-
-        foreach (str_split(strrev($shortUuid)) as $char) {
-            $number = gmp_add(
-                gmp_mul($number, $dictionaryLength),
-                (string) ($this->dictionary->charIndexes[$char] ?? (static function () : string {
-                    throw DictionaryException::indexOutOfBounds();
-                })())
-            );
+        if (1 !== preg_match($this->allowedCharactersMatcher, $shortUuid)) {
+            throw DictionaryException::indexOutOfBounds();
         }
 
-        $base16Uuid = str_pad(gmp_strval($number, 16), 32, '0', STR_PAD_LEFT);
+        $base16Uuid = str_pad(
+            gmp_strval(
+                gmp_init(
+                    strtr(strrev($shortUuid), array_flip($this->baseReplacements)),
+                    $this->dictionary->length
+                ),
+                16
+            ),
+            32,
+            '0',
+            STR_PAD_LEFT
+        );
 
         return substr($base16Uuid,0, 8)
             . '-'


### PR DESCRIPTION
Before:

```
\Benchmark\Keiko\Uuid\Shortener\GMPShortenerBench

    benchShorteningOfTinyUuid...............R5 I4 [μ Mo]/r: 5.160 5.200 (μs) [μSD μRSD]/r: 0.080μs 1.55%
    benchShorteningOfHugeUuid...............R1 I2 [μ Mo]/r: 35.560 35.883 (μs) [μSD μRSD]/r: 0.753μs 2.12%
    benchShorteningOfPromiscuousUuids.......R1 I4 [μ Mo]/r: 3,495.960 3,478.796 (μs) [μSD μRSD]/r: 87.504μs 2.50%
    benchExpandingOfTinyUuid................R5 I4 [μ Mo]/r: 7.160 7.122 (μs) [μSD μRSD]/r: 0.150μs 2.09%
    benchExpandingOfHugeUuid................R1 I0 [μ Mo]/r: 25.920 26.211 (μs) [μSD μRSD]/r: 0.627μs 2.42%
    benchExpandingOfPromiscuousUuids........R2 I1 [μ Mo]/r: 2,442.840 2,425.225 (μs) [μSD μRSD]/r: 53.328μs 2.18%
```

After:

```
\Benchmark\Keiko\Uuid\Shortener\GMPShortenerBench

    benchShorteningOfTinyUuid...............R1 I0 [μ Mo]/r: 4.000 4.000 (μs) [μSD μRSD]/r: 0.000μs 0.00%
    benchShorteningOfHugeUuid...............R1 I4 [μ Mo]/r: 4.200 4.085 (μs) [μSD μRSD]/r: 0.179μs 4.26%
    benchShorteningOfPromiscuousUuids.......R1 I2 [μ Mo]/r: 321.840 325.473 (μs) [μSD μRSD]/r: 6.486μs 2.02%
    benchExpandingOfTinyUuid................R5 I4 [μ Mo]/r: 19.240 19.649 (μs) [μSD μRSD]/r: 0.637μs 3.31%
    benchExpandingOfHugeUuid................R5 I4 [μ Mo]/r: 19.640 19.423 (μs) [μSD μRSD]/r: 0.427μs 2.17%
    benchExpandingOfPromiscuousUuids........R3 I3 [μ Mo]/r: 609.600 617.942 (μs) [μSD μRSD]/r: 16.369μs 2.69%
```

This is another 10x improvement on Promiscuous UUID shortening, which leads to 100x improvement over previous/baseline functionality