### PR TITLE
Allow brick/math 0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require": {
     "php": "^8.1",
-    "brick/math": "^0.12"
+    "brick/math": "^0.11 || ^0.12"
   },
   "require-dev": {
     "ext-gmp": "^8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9381d119d8758e179bf31e6bb8d8e6ec",
+    "content-hash": "e13ab0ff4e25a12655907f6def53839f",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
So we need to allow this again to not block installation of ramsey/uuid in version 4.

There is an open PR in ramsey/uuid to allow brick/math 0.12: https://github.com/ramsey/uuid/pull/526.