### PR TITLE
chore(deps): drop php version platform override

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,11 +44,6 @@
       "Test\\Keiko\\Uuid\\Shortener\\": "tests/"
     }
   },
-  "config": {
-    "platform": {
-      "php": "8.1.26"
-    }
-  },
   "scripts": {
     "code-style:check": "php-cs-fixer fix --dry-run --diff --ansi",
     "code-style:fix": "php-cs-fixer fix --diff --ansi",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47628f262a040f338661a30b755e2980",
+    "content-hash": "17d17ed5136a78062c08026a4f67adef",
     "packages": [
         {
             "name": "brick/math",
@@ -5635,9 +5635,6 @@
     },
     "platform-dev": {
         "ext-gmp": "^8.1"
-    },
-    "platform-overrides": {
-        "php": "8.1.26"
     },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Removed the PHP version override (8.1.26) to allow installing dependencies that require a higher minimum PHP version than the artificially defined config.platform